### PR TITLE
Implementar servidor de lenguaje para Quetzal

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "publisher": "antaresgt",
     "displayLanguage": "es",
     "main": "./out/extension.js",
+    "activationEvents": [
+        "onLanguage:quetzal",
+        "onCommand:quetzal.formatear_documento",
+        "onCommand:quetzal.ejecutar_archivo"
+    ],
     "contributes": {
         "languages": [
             {

--- a/recursos/ejemplos/bucles.qz
+++ b/recursos/ejemplos/bucles.qz
@@ -1,0 +1,44 @@
+// Bucle mientras
+entero var iterador_mientras = 0
+mientras (iterador_mientras < 10){
+    consola.mostrar("Iteración: " + iterador_mientras.texto())
+
+    iterador_mientras++
+}
+
+// Bucle para
+para (entero var i = 0; i < 5; i++) {
+    consola.mostrar("Bucle para, iteración: " + i.texto())
+}
+
+// Hacer
+entero var iterador_hacer = 0
+hacer {
+    consola.mostrar("Este mensaje se imprime al menos una vez.")
+    consola.mostrar("Iteración: " + iterador_hacer.texto())
+    iterador_hacer++
+} mientras (iterador_hacer < 3)
+
+// Bucle en
+lista<entero> lista_numeros = [10, 20, 30, 40, 50]
+para (entero var valor_numero en lista_numeros) {
+    consola.mostrar("Valor actual: " + valor_numero.texto())
+}
+
+// Bucle cada
+para (entero var valor_numero cada lista_numeros) {
+    consola.mostrar("Valor actual: " + valor_numero.texto())
+}
+
+// Salir de cualquier bucle, la palabra reservada "romper" nos permite salir de un bucle, no importando si es el bucle mientras, para, hacer o en
+entero var contador = 0
+mientras (contador < 10) {
+    consola.mostrar("Contador: " + contador.texto())
+
+    si (contador == 5) {
+        consola.mostrar("¡Contador alcanzó 5, saliendo del bucle!")
+        romper
+    }
+
+    contador++
+}

--- a/recursos/ejemplos/consola.qz
+++ b/recursos/ejemplos/consola.qz
@@ -1,0 +1,23 @@
+// Acá todos los metodos y ejemplos de la consola
+
+// Mostrar un texto en la consola, el texto se mostrará en el color por defecto
+consola.mostrar("¡Hola, Quetzal!")
+
+// Mostrar un texto de error en la consola, el texto se mostrará en rojo
+consola.mostrar_error("¡Error! No se pudo cargar el archivo.")
+
+// Mostrar un texto de advertencia en la consola, el texto se mostrará en amarillo
+consola.mostrar_advertencia("Advertencia: El archivo está corrupto.")
+
+// Mostrar un texto de éxito en la consola, el texto se mostrará en verde
+consola.mostrar_exito("¡Éxito! El archivo se cargó correctamente.")
+
+// Mostrar un texto de información en la consola, el texto se mostrará en azul
+consola.mostrar_informacion("Información: El proceso ha finalizado.")
+
+// Pedir una entrada al usuario por medio de la consola
+texto valor = consola.pedir("Por favor, ingresa tu nombre:")
+
+// Pedir una entrada secreta al usuario por medio de la consola
+texto clave = consola.pedir_secreto("Por favor, ingresa tu contraseña:")
+

--- a/recursos/ejemplos/control_de_flujo.qz
+++ b/recursos/ejemplos/control_de_flujo.qz
@@ -1,0 +1,21 @@
+// Controles de flujo
+
+entero edad = 41
+
+// Condicionales
+si (edad > 60) {
+    consola.mostrar("La persona es de la tercera edad")
+} sino si (edad > 18) {
+    consola.mostrar("La persona es mayor de edad")
+} sino {
+    consola.mostrar("La persona es menor de edad")
+}
+
+// Palabra reservada 'continuar', continua con la siguiente iteración del ciclo
+para (entero var i = 0; i < 10; i++) {
+    si (i % 2 == 0) {
+        // Si el número es par, se salta la impresión y se continua con la siguiente iteración
+        continuar
+    }
+    consola.mostrar(i)
+}

--- a/recursos/ejemplos/conversion_tipos.qz
+++ b/recursos/ejemplos/conversion_tipos.qz
@@ -1,0 +1,19 @@
+// Acá están todos los ejemplos de conversión de tipos
+
+// Textos a los otros tipos
+entero valor_entero = "1234".entero()
+número valor_numero = "1234.56".número()
+log valor_logico = "verdadero".log()
+jsn valor_json = "{\"clave\": \"valor\"}".jsn()
+lista<entero> lista_desde_texto = "1,2,3".lista()
+
+// Todas las conversiones a texto
+texto desde_entero = 1234.texto()
+texto desde_numero = 1234.56.texto()
+texto desde_logico = falso.texto()
+jsn valor_json2 = {
+    clave: "valor"
+}
+texto desde_json = valor_json2.texto()
+lista<entero> lista_enteros = [1, 2, 3]
+texto desde_lista = lista_enteros.texto()

--- a/recursos/ejemplos/exportar.qz
+++ b/recursos/ejemplos/exportar.qz
@@ -1,0 +1,41 @@
+
+entero sumar_entero(entero a, entero b) {
+    retornar a + b
+}
+
+objeto Usuario {
+    privado:
+        texto nombre
+        entero edad
+        libre número var saldo = 0
+    publico:
+        Usuario(texto nombre, entero edad) {
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
+
+        texto obtener_nombre() {
+            retornar ambiente.nombre
+        }
+
+        entero obtener_edad() {
+            retornar ambiente.edad
+        }
+}
+
+// Instancia de objeto
+Usuario instancia_usuario = nuevo Usuario("Juan", 30)
+
+// Declaración variable
+texto saludo = "Hola, Quetzal!"
+
+exportar {
+    // Exportar función
+    sumar_entero,
+    // Exportar definición de objeto
+    Usuario,
+    // Exportar instancia de objeto
+    instancia_usuario,
+    // Exportar variable
+    saludo
+}

--- a/recursos/ejemplos/funciones.qz
+++ b/recursos/ejemplos/funciones.qz
@@ -1,0 +1,88 @@
+// Funciones
+
+// Función que no devuelve valor
+vacio saludar() {
+    consola.mostrar("¡Hola, Quetzal!")
+}
+
+// Función que devuelve un número
+número sumar(número a, número b) {
+    retornar a + b
+}
+
+// Función que devuelve un entero
+entero multiplicar(entero a, entero b) {
+    retornar a * b
+}
+
+// Función que devuelve un texto
+texto concatenar(texto a, texto b) {
+    retornar a + b
+}
+
+// Función que devuelve un valor lógico
+log es_par(entero valor) {
+    retornar valor % 2 == 0
+}
+
+// Función que devuelve un JSON
+jsn obtener_datos() {
+    retornar {
+        nombre: "Quetzal",
+        version: "0.0.2",
+        tipos_soportados: ["entero", "número", "texto", "log", "lista", "jsn"]
+    }
+}
+
+// Función que devuelve una lista tipada de enteros
+lista<entero> obtener_numeros() {
+    retornar [1, 2, 3, 4, 5]
+}
+
+// Función que devuelve una lista no tipada de diferentes tipos
+lista obtener_datos_lista_no_tipada() {
+    retornar [1, "texto", verdadero, 3.14, [1, 2, 3]]
+}
+
+// Retornar objetos
+
+// Definir un objeto
+objeto DefinicionUsuario {
+    privado:
+        texto nombre
+        entero edad
+    publico:
+        DefinicionUsuario(texto nombre, entero edad){
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
+
+        texto obtener_nombre() {
+            retornar ambiente.nombre
+        }
+
+        entero obtener_edad() {
+            retornar ambiente.edad
+        }
+}
+
+// Función que retorna un objeto de tipo DefinicionUsuario
+DefinicionUsuario crear_usuario(texto nombre, entero edad) {
+    retornar nuevo DefinicionUsuario(nombre, edad)
+}
+
+// Funciones con tipos mutables
+texto funcion_con_parametros_modificables(texto var palabra){
+    palabra += " texto agregado."
+
+    retornar palabra
+}
+
+// Funciones recursivas
+entero factorial(entero n) {
+    si (n == 0) {
+        retornar 1
+    } sino {
+        retornar n * factorial(n - 1)
+    }
+}

--- a/recursos/ejemplos/manejo_excepciones.qz
+++ b/recursos/ejemplos/manejo_excepciones.qz
@@ -1,0 +1,27 @@
+// Las excepciones son eventos que ocurren durante la ejecución de un programa y que interrumpen su flujo normal.
+// En este ejemplo, se muestra cómo manejar excepciones en un programa de Quetzal.
+
+// Definimos una función que puede lanzar una excepción
+número dividir(número numerador, número denominador){
+    si (denominador == 0) {
+        lanzar "Error: División por cero no permitida"
+    }
+
+    retornar numerador / denominador
+}
+
+// Tratar la excepción al llamar a la función
+intentar {
+    número resultado = dividir(10, 0)
+    consola.mostrar("Resultado: " + resultado)
+} capturar (excepcion e){
+    // Obtenemos el mensaje de la excepción y lo imprimimos en la consola
+    consola.mostrar(e.mensaje)
+    // También podemos mostrar la pila de llamadas para ver dónde ocurrió la excepción
+    consola.mostrar("Pila de llamadas:" + e.llamadas.texto())
+}
+finalmente {
+    // Este bloque se ejecuta siempre, independientemente de si ocurrió una excepción o no
+    // No es obligatorio, pero es útil para limpiar recursos o mostrar mensajes finales
+    consola.mostrar("Fin del manejo de excepciones.")
+}

--- a/recursos/ejemplos/metodos_json.qz
+++ b/recursos/ejemplos/metodos_json.qz
@@ -1,0 +1,69 @@
+// Todos los metodos de JSON
+// Para que el JSON no sea constante, se debe agregar la palabra reservada "var"
+jsn var persona = {
+    nombre: "Ana",
+    datos_personales: {
+        fecha_nacimiento: "1998-05-15",
+        dpi: "1234567890101",
+        peso: 65.5,
+        altura: 1.70,
+        genero: "Femenino",
+        nacionalidad: "Guatemalteca",
+        estado_civil: "Soltera"
+    },
+    direcciones: [
+        {
+            tipo: "casa",
+            direccion: "123 Calle Principal, Ciudad"
+        },
+        {
+            tipo: "trabajo",
+            direccion: "456 Avenida Secundaria, Ciudad"
+        }
+    ],
+    telefonos: ["555-1234", "555-5678"],
+    activo: verdadero
+}
+
+// Acceso directo a propiedades
+texto nombre_persona = persona.nombre  // "Ana"
+// También otro acceso a propiedades
+número peso = persona["datos_personales"].peso  // 65.5
+// Acceso a propiedades anidadas
+texto direccion_casa = persona.direcciones[0].direccion  // "123 Calle Principal, Ciudad"
+// Acceso a un elemento de una lista dentro del JSON
+texto telefono_trabajo = persona.telefonos[1]  // "555-5678"
+
+// Verificar si una propiedad existe
+log tiene_dpi = persona.datos_personales.contiene_clave("dpi")  // verdadero
+
+// Obtener una lista de claves
+lista<texto> claves_persona = persona.claves()  // ["nombre", "datos_personales", "direcciones", "telefonos", "activo"]
+
+// Obtener una lista de valores
+lista valores_persona = persona.valores()  // ["Ana", {...}, ["casa", "trabajo"], ["555-1234", "555-5678"], verdadero]
+
+// Modificar una propiedad
+persona.nombre = "María"  // Cambia el nombre a "María"
+persona.establecer("nombre", "María")  // Alternativa para cambiar el nombre
+
+// Eliminar una propiedad
+persona.eliminar("activo")  // Elimina la propiedad "activo"
+
+// Fusionar o combinar dos JSON
+jsn var otra_persona = {
+    apellido: "Gómez",
+    edad: 30,
+    activo: falso
+}
+
+persona.fusionar(otra_persona)  // Combina los dos JSON, ahora persona tiene "apellido" y "edad"
+
+// Convertir JSON a texto
+texto persona_a_texto = persona.texto()  // '{"nombre":"María","datos_personales":{"fecha_nacimiento":"1998-05-15","dpi":"1234567890101","peso":65.5,"altura":1.7,"genero":"Femenino","nacionalidad":"Guatemalteca","estado_civil":"Soltera"},"direcciones":[{"tipo":"casa","direccion":"123 Calle Principal, Ciudad"},{"tipo":"trabajo","direccion":"456 Avenida Secundaria, Ciudad"}],"telefonos":["555-1234","555-5678"],"apellido":"Gómez","edad":30}'
+
+// Convertir JSON a un texto formateado
+texto persona_a_texto_formateado = persona.texto_formateado()  // Formato legible para humanos
+
+// Convertir texto a JSON
+jsn var json_desde_texto = "{\"nombre\":\"Ana\",\"edad\":25}".jsn()

--- a/recursos/ejemplos/metodos_listas.qz
+++ b/recursos/ejemplos/metodos_listas.qz
@@ -1,0 +1,126 @@
+// Metodos para listas
+
+// Acceso por indice (obtener elemento en posición)
+lista<texto> mi_lista = ["manzana", "banana", "cereza"]
+texto elemento = mi_lista[1]  // "banana" (índice 1)
+// Acceso por indice con índice negativo (desde el final)
+texto ultimo_elemento2 = mi_lista[-1]  // "cereza" (último elemento)
+
+// Acceso seguro (evita error si el índice no existe)
+intentar {
+    texto elemento_seguro = mi_lista[5]  // Error
+} capturar(excepcion ex){
+    consola.mostrar("Error al acceder a la lista: " + ex.mensaje)
+}
+
+// Longitud de la lista
+entero longitud = mi_lista.longitud()  // 3
+
+// Verificar si la lista está vacía
+log esta_vacia = mi_lista.esta_vacia()  // falso
+
+// Agregar un elemento al final de la lista
+// La lista debe ser mutable
+lista<texto> var lista_mutable = ["manzana", "banana"]
+lista_mutable.agregar("cereza")  // lista_mutable ahora es ["manzana", "banana", "cereza"]
+
+// Insertar un elemento en una posición específica
+lista_mutable.insertar(1, "naranja")  // lista_mutable ahora es ["manzana", "naranja", "banana", "cereza"]
+
+// Remover primera ocurrencia de un elemento
+lista_mutable.remover("banana")  // lista_mutable ahora es ["manzana", "naranja", "cereza"]
+
+// Remover elemento en una posición específica
+lista_mutable.quitar_en(0)  // lista_mutable ahora es ["naranja", "cereza"]
+
+// Vaciar la lista
+lista_mutable.limpiar()  // lista_mutable ahora es []
+
+// Verificar si un elemento está en la lista
+log contiene_elemento = mi_lista.contiene("banana")  // verdadero
+
+// Encontrar la posición de un elemento en la lista
+entero posicion_elemento = mi_lista.buscar("cereza")  // 2
+
+// Buscar último elemento coincidente
+entero posicion_ultimo = mi_lista.buscar_ultimo("manzana")  // 0 (posición de la última "manzana")
+
+// Contar ocurrencias de un elemento en la lista
+entero ocurrencias = mi_lista.contar("banana")  // 1
+
+// Ordenar ascendentemente
+// La lista debe ser mutable
+// Si la lista contiene elementos que no son comparables, lanzará un error
+lista<entero> var numeros = [3, 1, 4, 2]
+numeros.ordenar()  // numeros ahora es [1, 2, 3, 4]
+
+// Ordenar descendentemente
+numeros.ordenar_descendente()  // numeros ahora es [4, 3, 2, 1]
+
+// Crear una nueva lista ordenada sin modificar la original
+lista<entero> numeros_ordenados = numeros.ordenado()  // numeros_ordenados es [1, 2, 3, 4]
+
+// Invertir el orden de los elementos
+numeros.invertir()  // numeros ahora es [4, 3, 2, 1] (invertido)
+
+// Obtener primer elemento de la lista
+texto primer_elemento = mi_lista.primero()  // "manzana"
+
+// Obtener último elemento de la lista
+texto ultimo_elemento = mi_lista.ultimo()  // "cereza"
+
+// Primeros N elementos de la lista
+lista<texto> primeros_n = mi_lista.tomar(2)  // ["manzana", "banana"]
+
+// Omitir primeros N elementos de la lista
+lista<texto> omitidos_n = mi_lista.saltar(1)  // ["banana", "cereza"]
+
+// Sublista por rango
+lista<texto> sublista = mi_lista.sublista(0, 2)  // ["manzana", "banana"] (desde índice 0 hasta 2, sin incluir el 2)
+
+// Sumar todos los elementos de una lista de números
+lista<entero> numeros_lista = [1, 2, 3, 4, 5]
+entero suma = numeros_lista.sumar()  // 15
+
+// Sumar números
+lista<número> numeros_flotantes = [1.5, 2.5, 3.0]
+número suma_flotantes = numeros_flotantes.sumar()  // 7.0
+
+// Promedio de los elementos de una lista de números
+número promedio = numeros_lista.promedio()  // 3.0
+
+// Maximo de una lista de números
+entero maximo = numeros_lista.maximo()  // 5
+
+// Minimo de una lista de números
+entero minimo = numeros_lista.minimo()  // 1
+
+// Unir elementos como texto
+lista<texto> palabras = ["Hola", "mundo"]
+texto frase = palabras.unir(" ")  // "Hola mundo"
+
+// Concatenar dos listas
+lista<texto> lista1 = ["A", "B"]
+lista<texto> lista2 = ["C", "D"]
+lista<texto> concatenada = lista1.concatenar(lista2)  // ["A", "B", "C", "D"]
+
+// Extender una lista con otra lista
+lista<texto> var lista_base = ["A", "B"]
+lista<texto> lista_extender = ["C", "D"]
+lista_base.extender(lista_extender)  // lista_base ahora es ["A", "B", "C", "D"]
+
+// Convertir lista a texto
+texto lista_a_texto = mi_lista.texto() // "[manzana, banana, cereza]"
+
+// Convertir lista a json
+lista lista_objetos = [
+    {"nombre": "Juan", "edad": 30},
+    {"nombre": "Ana", "edad": 25}
+]
+texto lista_a_json = lista_objetos.json()  // '[{"nombre":"Juan","edad":30},{"nombre":"Ana","edad":25}]'
+
+// Convertir lista a valor lógico
+log lista_a_logico = mi_lista.logico()  // verdadero (si la lista no está vacía)
+
+// Crear lista de números consecutivos
+lista rango_numeros = rango(1, 10)  // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/recursos/ejemplos/metodos_texto.qz
+++ b/recursos/ejemplos/metodos_texto.qz
@@ -1,0 +1,198 @@
+// Todos los metodos de texto
+
+// Crear un texto de ejemplo
+texto mi_texto = "Hola Mundo"
+
+// Obtener la longitud del texto
+entero tamaño = mi_texto.longitud()
+
+// Conversión a otros tipos
+texto texto_num = "123"
+entero valor_numero = texto_num.entero()
+número decimal = texto_num.numero()
+
+// Caracteres especiales y Unicode
+texto con_acentos = "Programación en español: ñ, á, é, í, ó, ú"
+texto simbolos = "Símbolos especiales: @, #, $, %, &, *, +"
+texto emojis = "Emojis: 😀 🎉 🚀 ⭐"
+texto multilingual = "Español, English, Français, 中文, العربية"
+
+// Concatenación de textos
+texto nombre = "Juan"
+texto apellido = "Pérez"
+texto nombre_completo = nombre + " " + apellido // "Juan Pérez"
+
+// Concatenación con números
+entero edad = 25
+texto presentacion = "Tengo " + edad.texto() + " años" // "Tengo 25 años"
+
+// === INTERPOLACIÓN DE TEXTO ===
+// Nueva funcionalidad: Interpolación de texto con t"..."
+texto nombre_usuario = "María"
+entero puntos = 150
+
+// Interpolación básica
+texto saludo_interpolado = t"¡Hola {nombre_usuario}!"
+texto puntuacion = t"Tienes {puntos} puntos"
+
+// Interpolación con expresiones
+entero valor1 = 10
+entero valor2 = 5
+texto operaciones = t"Suma: {valor1 + valor2}, Multiplicación: {valor1 * valor2}, División: {valor1 / valor2}"
+
+// Interpolación con múltiples tipos
+número precio = 29.99
+log disponible = verdadero
+texto producto_info = t"Precio: ${precio}, Disponible: {disponible}"
+
+// Interpolación con listas
+lista numeros_fav = [7, 13, 21]
+texto lista_texto = t"Mis números favoritos: {numeros_fav}"
+
+// Interpolación multilínea usando escapes
+texto mensaje_completo = t"Estimado/a {nombre_usuario}, 
+Tus {puntos} puntos están disponibles.
+¡Gracias por usar Quetzal!
+Saludos, {nombre_usuario}
+"
+
+// Concatenación con asignación
+texto var saludo = "Hola"
+saludo += ", ¿cómo estás?" // "Hola, ¿cómo estás?"
+
+// Interpolación con expresiones
+entero a = 10
+entero b = 5
+texto calculo = t"La suma de {a} + {b} es {a + b}" // "La suma de 10 + 5 es 15"
+
+// Mayusculas
+texto mayusculas = mi_texto.mayusculas() // "HOLA MUNDO"
+// Minusculas
+texto minusculas = mi_texto.minusculas() // "hola mundo"
+// Capitalizar
+texto capitalizado = mi_texto.capitalizar() // "Hola mundo"
+// Cada letra inicial en mayuscula
+texto titulo = mi_texto.titulo() // "Hola Mundo"
+
+// Eliminar espacios al inicio y final
+texto con_espacios = " Hola Mundo ".recortar() // "Hola Mundo"
+
+// Eliminar espacios al inicio
+texto sin_espacios_inicio = " Hola Mundo ".recortar_inicio() // "Hola Mundo "
+
+// Eliminar espacios al final
+texto sin_espacios_final = " Hola Mundo ".recortar_final() // " Hola Mundo"
+
+// Verificar si un texto contiene otro texto
+log contiene = mi_texto.contiene("Mundo") // verdadero
+
+// Verificar si un texto empieza con otro texto
+log empieza_con = mi_texto.empieza_con("Hola") // verdadero
+
+// Verificar si un texto termina con otro texto
+log termina_con = mi_texto.termina_con("Mundo") // verdadero
+
+// Encontrar la posición de un texto dentro de otro
+entero posicion = mi_texto.encontrar("Mundo") // 5 (posición inicial), no encontrado devuelve -1
+
+// Buscar ultimo texto encontrado coincidente
+entero posicion_ultima = mi_texto.buscar_ultimo("o") // 7 (posición de la última 'o')
+
+// Reemplazar todas las ocurrencias de un texto por otro
+texto reemplazado = mi_texto.reemplazar("Mundo", "Quetzal") // "Hola Quetzal"
+
+// Reemplazar primera ocurrencia
+texto reemplazado_primero = mi_texto.reemplazar_primero("o", "0") // "H0la Mundo"
+
+// Dividir un texto en una lista por un separador
+lista<texto> partes = mi_texto.dividir(" ") // ["Hola", "Mundo"]
+
+// Partir texto en varias lineas o salto de lineas
+lista<texto> lineas = "Línea 1\nLínea 2\nLínea 3".partir_lineas() // ["Línea 1", "Línea 2", "Línea 3"]
+
+// Repetir un texto varias veces
+texto repetido = mi_texto.repetir(3) // "Hola MundoHola MundoHola Mundo"
+
+// Extraer porción de un texto (subtexto)
+texto subtexto = mi_texto.subtexto(0, 4) // "Hola" (desde índice 0 hasta 4, sin incluir el 4)
+
+// Extraer N caracteres desde el inicio
+texto izquierda = mi_texto.izquierda(4) // "Hola"
+
+// Extraer N caracteres desde el final
+texto derecha = mi_texto.derecha(4) // "Mundo"
+
+// Acceso por indice (obtener caracter en posición)
+texto caracter = mi_texto[1] // "o" (índice 1)
+// Acceso por indice con índice negativo (desde el final)
+texto ultimo_caracter = mi_texto[-1] // "o" (último carácter)
+
+// Metodo de validación
+log es_numero = "12345".es_numero() // verdadero
+log es_entero = "12345".es_entero() // verdadero
+
+// Metodo de alfanumerico
+log es_alfanumerico = "abc123".es_alfanumerico() // verdadero
+
+// Codificar a base64
+texto base64 = mi_texto.a_base64() // "SG9sYSBNdW5kbw == "
+
+// Decodificar de base64
+texto decodificado = "SG9sYSBNdW5kbw == ".decodificar_base64() // "Hola Mundo"
+
+// Codificar a URL
+texto url_codificada = "Hola Mundo!".a_url() // "Hola%20Mundo!"
+
+// Decodificar de URL
+texto url_decodificada = "Hola%20Mundo!".decodificar_url() // "Hola Mundo!"
+
+// Comparación insensible a mayúsculas
+log comparacion = "hola mundo".igual_sin_caso("Hola Mundo") // verdadero
+
+// Unir listas a textos con separador
+lista<texto> lista_textos = ["Hola", "Mundo", "desde", "Quetzal"]
+texto unido = lista_textos.unir(" ") // "Hola Mundo desde Quetzal"
+// Unir listas de enteros a textos con separador
+lista<entero> lista_enteros = [1, 2, 3, 4, 5]
+texto unido_enteros = lista_enteros.unir(", ") // "1, 2, 3, 4, 5"
+
+// Contar ocurrencias de un subtexto
+entero ocurrencias = "Hola Mundo, Hola Quetzal".contar("Hola") // 2
+
+// Invertir el texto
+texto invertido = mi_texto.invertir() // "odnuM aloH"
+
+// === INTERPOLACIÓN DE TEXTO ===
+
+// Interpolacion de texto basica
+entero val_a = 5
+entero val_b = 10
+consola.mostrar(t"La suma de {val_a} + {val_b} es: {val_a + val_b}")
+
+// Interpolacion con diferentes tipos
+texto nombre_lenguaje = "Quetzal"
+consola.mostrar(t"¡Hola desde el lenguaje {nombre_lenguaje}!")
+
+// Interpolacion con operaciones
+número pi = 3.14159
+log verdad = verdadero
+consola.mostrar(t"El valor de PI es {pi} y esto es {verdad}")
+
+// Interpolacion con listas
+lista numeros = [1, 2, 3]
+consola.mostrar(t"Mi lista: {numeros}")
+
+// Interpolacion con objetos JSON
+jsn datos_persona = {"nombre": "Juan", "edad": 30}
+consola.mostrar(t"Datos: {datos_persona}")
+
+// Interpolacion multilinea usando secuencias de escape
+texto planeta = "Mundo"
+consola.mostrar(t"Hola, 
+{planeta}
+!Este es un
+texto tabulado")
+
+// Interpolacion con escape de llaves
+entero numero_especial = 42
+consola.mostrar(t"El valor es {numero_especial} y esto son llaves literales: \\{valor2}")

--- a/recursos/ejemplos/modulos.qz
+++ b/recursos/ejemplos/modulos.qz
@@ -1,0 +1,16 @@
+// Importar funciones de otro archivo
+importar {
+    // Importar función
+    sumar_entero,
+    // Importar definición de objeto
+    Usuario,
+    // Importar instancia de objeto
+    instancia_usuario,
+    // Importar variable y colocar otro nombre "un alias"
+    saludo como texto_saludo
+} desde "exportar.qz"
+
+consola.mostrar(sumar_entero(5, 10))
+
+// Instanciar usuario mutable o variable
+Usuario var nuevo_usuario = nuevo Usuario("Juan", 30)

--- a/recursos/ejemplos/modulos_nativos_de_quetzal.qz
+++ b/recursos/ejemplos/modulos_nativos_de_quetzal.qz
@@ -1,0 +1,5 @@
+importar {
+    sumar
+} desde "quetzal/matemática"
+
+consola.mostrar(t"El resultado de 2 + 3 es: {sumar(2, 3)}")

--- a/recursos/ejemplos/objetos.qz
+++ b/recursos/ejemplos/objetos.qz
@@ -1,0 +1,100 @@
+// Declaración de objetos en Quetzal
+
+// Declaración común de un objeto
+objeto Usuario {
+    privado:
+        // Atributos privados del objeto
+        texto nombre
+        entero edad
+
+        // Funciones privadas del objeto
+        // Estas funciones solo pueden ser llamadas desde dentro del objeto
+        texto obtener_nombre_privado() {
+            retornar ambiente.nombre
+        }
+
+    publico:
+        // Constructor del objeto
+        Usuario(texto nombre, entero edad) {
+            // La palabra clave 'ambiente' se usa para referirse a las variables del objeto o funciones del objeto
+            // Se usa unicamente dentro del objeto
+            ambiente.nombre = nombre
+            ambiente.edad = edad
+        }
+
+        texto obtener_nombre() {
+            retornar ambiente.obtener_nombre_privado()
+        }
+
+        entero obtener_edad() {
+            retornar ambiente.edad
+        }
+}
+
+// Instantia un objeto
+Usuario usuario1 = nuevo Usuario("Juan", 30)
+
+// Los objetos que no se especifican las etiquetas de acceso son públicos por defecto
+objeto DefinicionUsuario {
+    texto nombre
+    entero edad
+
+    DefinicionUsuario(texto nombre, entero edad) {
+        ambiente.nombre = nombre
+        ambiente.edad = edad
+    }
+
+    texto obtener_nombre() {
+        retornar ambiente.nombre
+    }
+
+    entero obtener_edad() {
+        retornar ambiente.edad
+    }
+}
+
+// Instantia un objeto
+DefinicionUsuario usuario2 = nuevo DefinicionUsuario("Juan", 30)
+
+// Objeto con funciones libres y atributos libres
+objeto UsuarioLibre {
+
+    libre texto nombre
+    libre entero edad
+
+    libre entero absoluto(entero valor) {
+        retornar valor < 0 ? -valor : valor
+    }
+}
+
+
+// Los atributos libres y metodos libres se pueden acceder sin instanciar el objeto
+// Los metodos y atributos libres no pueden comunicarse con los atributos y metodos del objeto que si se instancian
+objeto UsuarioLibre2 {
+    privado:
+        // Atributos privados del objeto sin instanciar
+        // Los atributos privados no se pueden acceder desde afuera
+        libre texto var nombre = "Sin nombre"
+        libre entero var edad = 0
+
+        libre texto obtener_nombre() {
+            retornar ambiente.nombre
+        }
+
+        libre entero obtener_edad() {
+            retornar ambiente.edad
+        }
+    publico:
+
+        // Metodos que se pueden accerder desde afuera sin instanciar el objeto
+        libre vacio concatenar_apellido(texto nuevo_apellido) {
+            texto actual_nombre = ambiente.obtener_nombre()
+            ambiente.nombre = actual_nombre + " " + nuevo_apellido
+        }
+}
+
+// Las funciones libres se pueden llamar sin necesidad de instanciar el objeto
+entero valor_absoluto = UsuarioLibre.absoluto(-10)
+
+// Operar con el objeto libre
+UsuarioLibre2.concatenar_apellido("Pérez")

--- a/recursos/ejemplos/operadores.qz
+++ b/recursos/ejemplos/operadores.qz
@@ -1,0 +1,121 @@
+// Operadores
+
+// Operadores aritméticos
+entero suma(entero a, entero b) {
+    retornar a + b
+}
+
+entero resta(entero a, entero b) {
+    retornar a - b
+}
+
+// Operadores lógicos
+log es_verdadero(log valor) {
+    retornar valor
+}
+
+log es_falso(log valor) {
+    retornar !valor
+}
+
+// Operadores de comparación
+log es_igual(entero a, entero b) {
+    retornar a == b
+}
+
+log es_diferente(entero a, entero b) {
+    retornar a != b
+}
+
+log es_mayor(entero a, entero b) {
+    retornar a > b
+}
+
+log es_menor(entero a, entero b) {
+    retornar a < b
+}
+
+log es_mayor_igual(entero a, entero b) {
+    retornar a >= b
+}
+
+log es_menor_igual(entero a, entero b) {
+    retornar a <= b
+}
+
+// Operadores de asignación
+entero asignacion(entero valor) {
+    entero resultado = valor
+    retornar resultado
+}
+
+// Operadores de concatenación
+texto concatenacion(texto var palabra) {
+    palabra += " concatenado"
+    retornar palabra
+}
+
+// Operadores de incremento y decremento
+entero incremento(entero var valor) {
+    valor++
+    retornar valor
+}
+
+entero decremento(entero var valor) {
+    valor--
+    retornar valor
+}
+
+// Operadores compuestos
+entero suma_compuesta(entero var valor, entero incremento) {
+    valor += incremento
+    retornar valor
+}
+
+entero resta_compuesta(entero var valor, entero decremento) {
+    valor -= decremento
+    retornar valor
+}
+
+entero multiplicacion_compuesta(entero var valor, entero factor) {
+    valor *= factor
+    retornar valor
+}
+
+entero division_compuesta(entero var valor, entero divisor) {
+    valor /= divisor
+    retornar valor
+}
+
+entero modulo_compuesta(entero var valor, entero divisor) {
+    valor %= divisor
+    retornar valor
+}
+
+// Operadores de cadena
+texto agregar_texto(texto var palabra, texto agregado) {
+    palabra += agregado
+    retornar palabra
+}
+
+// Ejecutar funciones para comprobar operadores
+entero resultado_suma = suma(5, 10)
+entero resultado_resta = resta(10, 5)
+log resultado_es_verdadero = es_verdadero(verdadero)
+log resultado_es_falso = es_falso(falso)
+log resultado_es_igual = es_igual(5, 5)
+log resultado_es_diferente = es_diferente(5, 10)
+log resultado_es_mayor = es_mayor(10, 5)
+log resultado_es_menor = es_menor(5, 10)
+log resultado_es_mayor_igual = es_mayor_igual(5, 5)
+log resultado_es_menor_igual = es_menor_igual(5, 5)
+entero resultado_asignacion = asignacion(10)
+texto resultado_concatenacion = concatenacion("Hola")
+entero resultado_incremento = incremento(5)
+entero resultado_decremento = decremento(5)
+entero resultado_suma_compuesta = suma_compuesta(5, 10)
+entero resultado_resta_compuesta = resta_compuesta(10, 5)
+entero resultado_multiplicacion_compuesta = multiplicacion_compuesta(5, 10)
+entero resultado_division_compuesta = division_compuesta(10, 5)
+entero resultado_modulo_compuesta = modulo_compuesta(10, 5)
+texto resultado_agregar_texto = agregar_texto("Hola", " Mundo")

--- a/recursos/ejemplos/textos.qz
+++ b/recursos/ejemplos/textos.qz
@@ -1,0 +1,10 @@
+// Textos
+
+// Texto constante
+texto saludo = "Hola, "
+// Texto variable o mutable, se identifica con la palabra reservada var
+texto var mundo = "Mundo!"
+
+mundo += " Quetzal"
+
+consola.mostrar(saludo + mundo)

--- a/recursos/ejemplos/tipos.qz
+++ b/recursos/ejemplos/tipos.qz
@@ -1,0 +1,56 @@
+// Acá están todos los tipos soportados por Quetzal v0.0.2
+// Por defecto, las variables siempre son constantes, a menos que se use la palabra clave 'var' para definirlas como variables mutables
+// Tipos primitivos
+entero valor_entero = 3
+número valor_numero = 3.1416
+texto valor_texto = "Hola, Quetzal"
+log valor_logico = verdadero
+// Lista no tipada
+lista valor_lista = [1, 2, "Texto", verdadero, [1, "otra lista"]]
+// Lista tipada
+lista<entero> valor_lista_tipada = [1, 2, 3, 4, 5]
+// El tipo vacio no puede ser usado como variable, pero si como función
+vacio funcion_vacia() {}
+
+// JSON nativo
+jsn valor_json = {
+    valor_entero: 42,
+    valor_numero: 2.718,
+    valor_texto: "Texto en JSON",
+    valor_logico: falso,
+    valor_lista: [1, 2, 3],
+    valor_otro_json: {
+        clave: "valor",
+        otro: [1, 2, 3]
+    }
+}
+
+// Tipos mutables
+entero var valor_entero_mutable = 10
+número var valor_numero_mutable = 2.71828
+texto var valor_texto_mutable = "Texto mutable"
+log var valor_logico_mutable = falso
+// Lista mutable no tipada
+lista var valor_lista_mutable = [1, 2, 3]
+// Lista mutable tipada
+lista<entero> var valor_lista_tipada_mutable = [1, 2, 3, 4, 5]
+// JSON mutable
+jsn var valor_json_mutable = {
+    clave: "valor",
+    lista_ejemplo: [1, 2, 3],
+    objeto_ejemplo: {
+        subclave: "subvalor"
+    }
+}
+
+// nulo, este es un valor que se le puede asignar a cualquier tipo de dato, indicando que no tiene valor
+entero valor_entero_nulo = nulo
+número valor_numero_nulo = nulo
+texto valor_texto_nulo = nulo
+log valor_logico_nulo = nulo
+// Lista no tipada nula
+lista valor_lista_nula = nulo
+// Lista tipada nula
+lista<entero> valor_lista_tipada_nula = nulo
+// JSON nulo
+jsn valor_json_nulo = nulo

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,20 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
-import { ServidorLenguajeQuetzal } from './servidor_lenguaje';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { FormateadorQuetzal } from './formateador';
-import { ProveedorCompletado } from './proveedor_completado';
 import { DiagnosticadorQuetzal } from './diagnosticador';
+
+let clienteLenguaje: LanguageClient | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Extensión Lenguaje Quetzal activada');
 
-    // Inicializar servidor de lenguaje
-    const servidor_lenguaje = new ServidorLenguajeQuetzal();
-    
+    // Inicializar servidor de lenguaje con implementación LSP
+    inicializar_servidor_lenguaje(context);
+
     // Inicializar formateador
     const formateador = new FormateadorQuetzal();
-    
-    // Inicializar proveedor de autocompletado
-    const proveedor_completado = new ProveedorCompletado(servidor_lenguaje);
-    
+
     // Inicializar diagnosticador
     const diagnosticador = new DiagnosticadorQuetzal();
 
@@ -50,25 +49,6 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    // Registrar proveedor de autocompletado
-    const proveedor_completado_registrado = vscode.languages.registerCompletionItemProvider(
-        'quetzal',
-        proveedor_completado,
-        '.', '(', ' '
-    );
-
-    // Registrar proveedor de hover información
-    const proveedor_hover = vscode.languages.registerHoverProvider('quetzal', {
-        provideHover(document, position, token) {
-            const palabra = document.getWordRangeAtPosition(position);
-            if (palabra) {
-                const texto_palabra = document.getText(palabra);
-                return proveedor_completado.obtener_informacion_hover(texto_palabra);
-            }
-            return null;
-        }
-    });
-
     // Registrar diagnosticador para errores de sintaxis
     const coleccion_diagnosticos = vscode.languages.createDiagnosticCollection('quetzal');
     
@@ -98,8 +78,6 @@ export function activate(context: vscode.ExtensionContext) {
         comando_formatear,
         comando_ejecutar,
         proveedor_formato,
-        proveedor_completado_registrado,
-        proveedor_hover,
         coleccion_diagnosticos,
         cambio_documento,
         apertura_documento
@@ -110,4 +88,46 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
     console.log('Extensión Lenguaje Quetzal desactivada');
+    if (clienteLenguaje) {
+        clienteLenguaje.stop();
+    }
+}
+
+function inicializar_servidor_lenguaje(context: vscode.ExtensionContext): void {
+    const rutaServidor = context.asAbsolutePath(path.join('out', 'servidor', 'servidor.js'));
+    const rutaEjemplos = context.asAbsolutePath(path.join('recursos', 'ejemplos'));
+
+    const opcionesServidor: ServerOptions = {
+        run: {
+            module: rutaServidor,
+            transport: TransportKind.ipc
+        },
+        debug: {
+            module: rutaServidor,
+            transport: TransportKind.ipc,
+            options: {
+                execArgv: ['--nolazy', '--inspect=6009']
+            }
+        }
+    };
+
+    const opcionesCliente: LanguageClientOptions = {
+        documentSelector: [{ scheme: 'file', language: 'quetzal' }],
+        initializationOptions: {
+            rutaEjemplos
+        },
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.qz')
+        }
+    };
+
+    clienteLenguaje = new LanguageClient(
+        'quetzalLenguajeServidor',
+        'Servidor de Lenguaje Quetzal',
+        opcionesServidor,
+        opcionesCliente
+    );
+
+    clienteLenguaje.start();
+    context.subscriptions.push(clienteLenguaje);
 }

--- a/src/servidor/analizador.ts
+++ b/src/servidor/analizador.ts
@@ -1,0 +1,172 @@
+import * as path from 'path';
+
+const IDENTIFICADOR = String.raw`[\p{L}_][\p{L}\p{N}_]*`;
+const PATRON_TIPO = String.raw`(?:entero|número|numero|texto|cadena|log|bool|lista\s*<\s*[^>]+?\s*>|lista|jsn|vacio|vacío|[A-Z][\p{L}\p{N}_]*)`;
+
+export interface FuncionAnalizada {
+    nombre: string;
+    tipoRetorno?: string;
+    parametros: string[];
+}
+
+export interface VariableAnalizada {
+    nombre: string;
+    tipo: string;
+}
+
+export interface ObjetoAnalizado {
+    nombre: string;
+}
+
+export interface ExportacionAnalizada {
+    nombre: string;
+    alias?: string;
+    tipo?: string;
+}
+
+export interface ImportacionAnalizada {
+    modulo: string;
+    elementos: ExportacionAnalizada[];
+}
+
+export interface AnalisisDocumento {
+    funciones: FuncionAnalizada[];
+    variables: VariableAnalizada[];
+    objetos: ObjetoAnalizado[];
+    exportaciones: ExportacionAnalizada[];
+    importaciones: ImportacionAnalizada[];
+    identificadores: Map<string, string>;
+}
+
+export function limpiarComentarios(texto: string): string {
+    const sinComentariosLinea = texto.replace(/\/\/.*$/gm, '');
+    return sinComentariosLinea.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function extraerNombreParametro(parametro: string): string {
+    const limpio = parametro.trim();
+    if (!limpio) {
+        return '';
+    }
+    const partes = limpio.split(/\s+/u);
+    return partes[partes.length - 1] ?? limpio;
+}
+
+function normalizarTipo(tipo: string): string {
+    const limpio = tipo.trim();
+    if (limpio.includes('\n')) {
+        return limpio.replace(/\s+/g, ' ');
+    }
+    return limpio;
+}
+
+function dividirElementosLista(texto: string): string[] {
+    const sinSaltos = texto.replace(/\n/g, ' ');
+    const partes = sinSaltos.split(',');
+    return partes
+        .map(parte => parte.trim())
+        .filter(parte => parte.length > 0);
+}
+
+export function analizarTextoQuetzal(texto: string): AnalisisDocumento {
+    const textoLimpio = limpiarComentarios(texto);
+    const funciones: FuncionAnalizada[] = [];
+    const variables: VariableAnalizada[] = [];
+    const objetos: ObjetoAnalizado[] = [];
+    const exportaciones: ExportacionAnalizada[] = [];
+    const importaciones: ImportacionAnalizada[] = [];
+    const identificadores = new Map<string, string>();
+
+    const regexObjeto = new RegExp(String.raw`\bobjeto\s+(${IDENTIFICADOR})\s*\{`, 'gu');
+    let coincidencia: RegExpExecArray | null;
+    while ((coincidencia = regexObjeto.exec(textoLimpio)) !== null) {
+        const nombre = coincidencia[1];
+        objetos.push({ nombre });
+        identificadores.set(nombre, nombre);
+    }
+
+    const regexFuncionNueva = new RegExp(String.raw`\b(${PATRON_TIPO})\s+(${IDENTIFICADOR})\s*\(([^)]*)\)\s*\{`, 'gu');
+    while ((coincidencia = regexFuncionNueva.exec(textoLimpio)) !== null) {
+        const tipo = normalizarTipo(coincidencia[1]);
+        const nombre = coincidencia[2];
+        const parametros = coincidencia[3]
+            .split(',')
+            .map(p => extraerNombreParametro(p))
+            .filter(p => p.length > 0);
+        funciones.push({ nombre, tipoRetorno: tipo, parametros });
+        identificadores.set(nombre, tipo);
+    }
+
+    const regexFuncionLegacy = new RegExp(String.raw`\b(?:función|funcion|fn)\s+(${IDENTIFICADOR})\s*\(([^)]*)\)\s*\{`, 'gu');
+    while ((coincidencia = regexFuncionLegacy.exec(textoLimpio)) !== null) {
+        const nombre = coincidencia[1];
+        const parametros = coincidencia[2]
+            .split(',')
+            .map(p => extraerNombreParametro(p))
+            .filter(p => p.length > 0);
+        funciones.push({ nombre, parametros });
+        identificadores.set(nombre, 'desconocido');
+    }
+
+    const regexVariable = new RegExp(String.raw`\b(${PATRON_TIPO})\s+(?:var\s+)?(${IDENTIFICADOR})\b`, 'gu');
+    while ((coincidencia = regexVariable.exec(textoLimpio)) !== null) {
+        const tipo = normalizarTipo(coincidencia[1]);
+        const nombre = coincidencia[2];
+        const posicionFinal = regexVariable.lastIndex;
+        const resto = textoLimpio.slice(posicionFinal).trimStart();
+        if (resto.startsWith('(')) {
+            continue;
+        }
+        variables.push({ nombre, tipo });
+        identificadores.set(nombre, tipo);
+    }
+
+    const regexImportacion = /importar\s*\{([\s\S]*?)\}\s*desde\s*"([^"]+)"/gu;
+    while ((coincidencia = regexImportacion.exec(textoLimpio)) !== null) {
+        const cuerpo = coincidencia[1];
+        const modulo = coincidencia[2];
+        const partes = dividirElementosLista(cuerpo.replace(/\/\/.*$/gm, ''));
+        const elementos: ExportacionAnalizada[] = [];
+        for (const parte of partes) {
+            const matchElemento = parte.match(new RegExp(String.raw`^(${IDENTIFICADOR})(?:\s+como\s+(${IDENTIFICADOR}))?$`, 'u'));
+            if (matchElemento) {
+                const nombre = matchElemento[1];
+                const alias = matchElemento[2];
+                elementos.push({ nombre, alias });
+            }
+        }
+        importaciones.push({ modulo, elementos });
+    }
+
+    const regexExportacion = /exportar\s*\{([\s\S]*?)\}/gu;
+    while ((coincidencia = regexExportacion.exec(textoLimpio)) !== null) {
+        const cuerpo = coincidencia[1];
+        const partes = dividirElementosLista(cuerpo.replace(/\/\/.*$/gm, ''));
+        for (const parte of partes) {
+            const matchElemento = parte.match(new RegExp(String.raw`^(${IDENTIFICADOR})(?:\s+como\s+(${IDENTIFICADOR}))?$`, 'u'));
+            if (matchElemento) {
+                const nombre = matchElemento[1];
+                const alias = matchElemento[2];
+                const tipo = identificadores.get(nombre);
+                exportaciones.push({ nombre, alias, tipo });
+            }
+        }
+    }
+
+    return { funciones, variables, objetos, exportaciones, importaciones, identificadores };
+}
+
+export function normalizarRutaModulo(ruta: string): string {
+    const conExtension = ruta.endsWith('.qz') ? ruta : `${ruta}.qz`;
+    const rutaNormalizada = conExtension.replace(/\\/g, '/');
+    return rutaNormalizada.startsWith('.') ? rutaNormalizada : rutaNormalizada;
+}
+
+export function rutaRelativa(documentoFs: string, destinoFs: string): string {
+    const directorioDocumento = path.dirname(documentoFs);
+    let relativa = path.relative(directorioDocumento, destinoFs);
+    if (!relativa.startsWith('.')) {
+        relativa = `./${relativa}`;
+    }
+    return relativa.replace(/\\/g, '/');
+}

--- a/src/servidor/datos_base.ts
+++ b/src/servidor/datos_base.ts
@@ -1,0 +1,207 @@
+import { CompletionItemKind, InsertTextFormat } from 'vscode-languageserver/node';
+
+export interface DefinicionMetodo {
+    nombre: string;
+    retorno?: string;
+    snippet?: string;
+}
+
+export interface DefinicionFuncion {
+    nombre: string;
+    descripcion?: string;
+    snippet?: string;
+}
+
+export interface DefinicionPalabra {
+    etiqueta: string;
+    descripcion: string;
+    tipo: CompletionItemKind;
+    snippet?: string;
+}
+
+export const PALABRAS_RESERVADAS: DefinicionPalabra[] = [
+    { etiqueta: 'si', descripcion: 'Condicional si', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'sino', descripcion: 'Condicional sino', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'mientras', descripcion: 'Bucle mientras', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'para', descripcion: 'Bucle para', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'hacer', descripcion: 'Bucle hacer-mientras', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'romper', descripcion: 'Romper bucle', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'continuar', descripcion: 'Continuar bucle', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'retornar', descripcion: 'Retornar valor', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'var', descripcion: 'Variable mutable', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'función', descripcion: 'Definir función (con tilde)', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'funcion', descripcion: 'Definir función', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'objeto', descripcion: 'Definir objeto', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'nuevo', descripcion: 'Crear nueva instancia', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'ambiente', descripcion: 'Referencia al objeto actual', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'importar', descripcion: 'Importar módulo', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'exportar', descripcion: 'Exportar elementos', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'desde', descripcion: 'Especificar origen de importación', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'como', descripcion: 'Crear alias en importación', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'intentar', descripcion: 'Bloque intentar', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'atrapar', descripcion: 'Bloque atrapar', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'capturar', descripcion: 'Bloque capturar', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'finalmente', descripcion: 'Bloque finalmente', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'lanzar', descripcion: 'Lanzar excepción', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'esperar', descripcion: 'Esperar resultado asíncrono', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'asincrono', descripcion: 'Función asíncrona', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'asíncrono', descripcion: 'Función asíncrona (con tilde)', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'y', descripcion: 'Operador lógico AND', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'o', descripcion: 'Operador lógico OR', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'mut', descripcion: 'Modificador mutable (legacy)', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'público', descripcion: 'Miembro público (con tilde)', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'publico', descripcion: 'Miembro público', tipo: CompletionItemKind.Keyword },
+    { etiqueta: 'privado', descripcion: 'Miembro privado', tipo: CompletionItemKind.Keyword }
+];
+
+export const TIPOS_BÁSICOS: DefinicionPalabra[] = [
+    { etiqueta: 'vacío', descripcion: 'Tipo sin valor (con tilde)', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'vacio', descripcion: 'Tipo sin valor', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'entero', descripcion: 'Número entero', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'número', descripcion: 'Número decimal (con tilde)', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'numero', descripcion: 'Número decimal', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'texto', descripcion: 'Cadena de texto', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'cadena', descripcion: 'Cadena de texto (legacy)', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'log', descripcion: 'Valor lógico', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'bool', descripcion: 'Valor booleano (legacy)', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'lista', descripcion: 'Lista de elementos', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'jsn', descripcion: 'Objeto JSON', tipo: CompletionItemKind.TypeParameter },
+    { etiqueta: 'verdadero', descripcion: 'Valor booleano verdadero', tipo: CompletionItemKind.Value },
+    { etiqueta: 'falso', descripcion: 'Valor booleano falso', tipo: CompletionItemKind.Value },
+    { etiqueta: 'nulo', descripcion: 'Valor nulo', tipo: CompletionItemKind.Value }
+];
+
+export const METODOS_PREDEFINIDOS: Record<string, DefinicionMetodo[]> = {
+    texto: [
+        { nombre: 'longitud()', retorno: 'entero' },
+        { nombre: 'entero()', retorno: 'entero' },
+        { nombre: 'numero()', retorno: 'número' },
+        { nombre: 'mayusculas()', retorno: 'texto' },
+        { nombre: 'minusculas()', retorno: 'texto' },
+        { nombre: 'capitalizar()', retorno: 'texto' },
+        { nombre: 'titulo()', retorno: 'texto' },
+        { nombre: 'recortar()', retorno: 'texto' },
+        { nombre: 'recortar_inicio()', retorno: 'texto' },
+        { nombre: 'recortar_final()', retorno: 'texto' },
+        { nombre: 'contiene(${1:subtexto})', retorno: 'log', snippet: 'contiene(${1:subtexto})' },
+        { nombre: 'empieza_con(${1:prefijo})', retorno: 'log', snippet: 'empieza_con(${1:prefijo})' },
+        { nombre: 'termina_con(${1:sufijo})', retorno: 'log', snippet: 'termina_con(${1:sufijo})' },
+        { nombre: 'encontrar(${1:subtexto})', retorno: 'entero', snippet: 'encontrar(${1:subtexto})' },
+        { nombre: 'buscar_ultimo(${1:subtexto})', retorno: 'entero', snippet: 'buscar_ultimo(${1:subtexto})' },
+        { nombre: 'reemplazar(${1:buscar}, ${2:reemplazo})', retorno: 'texto', snippet: 'reemplazar(${1:buscar}, ${2:reemplazo})' },
+        { nombre: 'reemplazar_primero(${1:buscar}, ${2:reemplazo})', retorno: 'texto', snippet: 'reemplazar_primero(${1:buscar}, ${2:reemplazo})' },
+        { nombre: 'dividir(${1:separador})', retorno: 'lista<texto>', snippet: 'dividir(${1:separador})' },
+        { nombre: 'partir_lineas()', retorno: 'lista<texto>' },
+        { nombre: 'repetir(${1:veces})', retorno: 'texto', snippet: 'repetir(${1:veces})' },
+        { nombre: 'subtexto(${1:inicio}, ${2:fin})', retorno: 'texto', snippet: 'subtexto(${1:inicio}, ${2:fin})' },
+        { nombre: 'izquierda(${1:n})', retorno: 'texto', snippet: 'izquierda(${1:n})' },
+        { nombre: 'derecha(${1:n})', retorno: 'texto', snippet: 'derecha(${1:n})' },
+        { nombre: 'es_numero()', retorno: 'log' },
+        { nombre: 'es_entero()', retorno: 'log' },
+        { nombre: 'es_alfanumerico()', retorno: 'log' },
+        { nombre: 'a_base64()', retorno: 'texto' },
+        { nombre: 'decodificar_base64()', retorno: 'texto' },
+        { nombre: 'a_url()', retorno: 'texto' },
+        { nombre: 'decodificar_url()', retorno: 'texto' },
+        { nombre: 'igual_sin_caso(${1:otro})', retorno: 'log', snippet: 'igual_sin_caso(${1:otro})' },
+        { nombre: 'jsn()', retorno: 'jsn' }
+    ],
+    lista: [
+        { nombre: 'longitud()', retorno: 'entero' },
+        { nombre: 'esta_vacia()', retorno: 'log' },
+        { nombre: 'agregar(${1:valor})', retorno: 'vacío', snippet: 'agregar(${1:valor})' },
+        { nombre: 'insertar(${1:indice}, ${2:valor})', retorno: 'vacío', snippet: 'insertar(${1:indice}, ${2:valor})' },
+        { nombre: 'remover(${1:valor})', retorno: 'vacío', snippet: 'remover(${1:valor})' },
+        { nombre: 'quitar_en(${1:indice})', retorno: 'vacío', snippet: 'quitar_en(${1:indice})' },
+        { nombre: 'limpiar()', retorno: 'vacío' },
+        { nombre: 'contiene(${1:valor})', retorno: 'log', snippet: 'contiene(${1:valor})' },
+        { nombre: 'buscar(${1:valor})', retorno: 'entero', snippet: 'buscar(${1:valor})' },
+        { nombre: 'buscar_ultimo(${1:valor})', retorno: 'entero', snippet: 'buscar_ultimo(${1:valor})' },
+        { nombre: 'contar(${1:valor})', retorno: 'entero', snippet: 'contar(${1:valor})' },
+        { nombre: 'ordenar()', retorno: 'vacío' },
+        { nombre: 'ordenar_descendente()', retorno: 'vacío' },
+        { nombre: 'ordenado()', retorno: 'lista' },
+        { nombre: 'invertir()', retorno: 'vacío' },
+        { nombre: 'primero()', retorno: 'elemento' },
+        { nombre: 'ultimo()', retorno: 'elemento' },
+        { nombre: 'tomar(${1:n})', retorno: 'lista', snippet: 'tomar(${1:n})' },
+        { nombre: 'saltar(${1:n})', retorno: 'lista', snippet: 'saltar(${1:n})' },
+        { nombre: 'sublista(${1:inicio}, ${2:fin})', retorno: 'lista', snippet: 'sublista(${1:inicio}, ${2:fin})' },
+        { nombre: 'sumar()', retorno: 'número' },
+        { nombre: 'promedio()', retorno: 'número' },
+        { nombre: 'maximo()', retorno: 'entero' },
+        { nombre: 'minimo()', retorno: 'entero' },
+        { nombre: 'unir(${1:separador})', retorno: 'texto', snippet: 'unir(${1:separador})' },
+        { nombre: 'concatenar(${1:otra_lista})', retorno: 'lista', snippet: 'concatenar(${1:otra_lista})' },
+        { nombre: 'extender(${1:otra_lista})', retorno: 'vacío', snippet: 'extender(${1:otra_lista})' },
+        { nombre: 'texto()', retorno: 'texto' },
+        { nombre: 'json()', retorno: 'texto' },
+        { nombre: 'logico()', retorno: 'log' }
+    ],
+    jsn: [
+        { nombre: 'contiene_clave(${1:clave})', retorno: 'log', snippet: 'contiene_clave(${1:clave})' },
+        { nombre: 'claves()', retorno: 'lista<texto>' },
+        { nombre: 'valores()', retorno: 'lista' },
+        { nombre: 'establecer(${1:clave}, ${2:valor})', retorno: 'vacío', snippet: 'establecer(${1:clave}, ${2:valor})' },
+        { nombre: 'eliminar(${1:clave})', retorno: 'vacío', snippet: 'eliminar(${1:clave})' },
+        { nombre: 'fusionar(${1:otro_jsn})', retorno: 'vacío', snippet: 'fusionar(${1:otro_jsn})' },
+        { nombre: 'texto()', retorno: 'texto' },
+        { nombre: 'texto_formateado()', retorno: 'texto' }
+    ],
+    numero: [
+        { nombre: 'texto()', retorno: 'texto' }
+    ],
+    'número': [
+        { nombre: 'texto()', retorno: 'texto' }
+    ],
+    entero: [
+        { nombre: 'texto()', retorno: 'texto' }
+    ],
+    log: [
+        { nombre: 'texto()', retorno: 'texto' }
+    ],
+    consola: [
+        { nombre: 'mostrar(${1:texto})', retorno: 'vacío', snippet: 'mostrar(${1:texto})' },
+        { nombre: 'mostrar_error(${1:texto})', retorno: 'vacío', snippet: 'mostrar_error(${1:texto})' },
+        { nombre: 'mostrar_advertencia(${1:texto})', retorno: 'vacío', snippet: 'mostrar_advertencia(${1:texto})' },
+        { nombre: 'mostrar_exito(${1:texto})', retorno: 'vacío', snippet: 'mostrar_exito(${1:texto})' },
+        { nombre: 'mostrar_informacion(${1:texto})', retorno: 'vacío', snippet: 'mostrar_informacion(${1:texto})' },
+        { nombre: 'pedir(${1:mensaje})', retorno: 'texto', snippet: 'pedir(${1:mensaje})' },
+        { nombre: 'pedir_secreto(${1:mensaje})', retorno: 'texto', snippet: 'pedir_secreto(${1:mensaje})' }
+    ]
+};
+
+export const FUNCIONES_DEPRECADAS: DefinicionPalabra[] = [
+    {
+        etiqueta: 'imprimir',
+        descripcion: 'Reemplazado por consola.mostrar("texto")',
+        tipo: CompletionItemKind.Function,
+        snippet: 'imprimir(${1:mensaje})'
+    },
+    {
+        etiqueta: 'imprimir_exito',
+        descripcion: 'Reemplazado por consola.mostrar_exito("texto")',
+        tipo: CompletionItemKind.Function,
+        snippet: 'imprimir_exito(${1:mensaje})'
+    },
+    {
+        etiqueta: 'imprimir_error',
+        descripcion: 'Reemplazado por consola.mostrar_error("texto")',
+        tipo: CompletionItemKind.Function,
+        snippet: 'imprimir_error(${1:mensaje})'
+    },
+    {
+        etiqueta: 'imprimir_advertencia',
+        descripcion: 'Reemplazado por consola.mostrar_advertencia("texto")',
+        tipo: CompletionItemKind.Function,
+        snippet: 'imprimir_advertencia(${1:mensaje})'
+    },
+    {
+        etiqueta: 'imprimir_informacion',
+        descripcion: 'Reemplazado por consola.mostrar_informacion("texto")',
+        tipo: CompletionItemKind.Function,
+        snippet: 'imprimir_informacion(${1:mensaje})'
+    }
+];
+
+export const FORMATO_SNIPPET = InsertTextFormat.Snippet;

--- a/src/servidor/servidor.ts
+++ b/src/servidor/servidor.ts
@@ -1,0 +1,587 @@
+import {
+    CompletionItem,
+    CompletionItemKind,
+    CompletionItemTag,
+    CompletionParams,
+    FileChangeType,
+    InsertTextFormat,
+    InitializeParams,
+    InitializeResult,
+    Position,
+    ProposedFeatures,
+    TextDocuments,
+    TextDocumentSyncKind,
+    createConnection
+} from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { fileURLToPath } from 'url';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    DefinicionPalabra,
+    FORMATO_SNIPPET,
+    FUNCIONES_DEPRECADAS,
+    METODOS_PREDEFINIDOS,
+    PALABRAS_RESERVADAS,
+    TIPOS_BÁSICOS
+} from './datos_base';
+import {
+    AnalisisDocumento,
+    ExportacionAnalizada,
+    FuncionAnalizada,
+    ImportacionAnalizada,
+    ObjetoAnalizado,
+    VariableAnalizada,
+    analizarTextoQuetzal
+} from './analizador';
+
+const connection = createConnection(ProposedFeatures.all);
+const documentos = new TextDocuments(TextDocument);
+
+const IDENTIFICADOR_REGEX = String.raw`[\p{L}_][\p{L}\p{N}_]*`;
+
+type OrigenArchivo = 'usuario' | 'ejemplo';
+
+interface RegistroAnalisis {
+    ruta: string;
+    analisis: AnalisisDocumento;
+}
+
+interface ConocimientoGlobal {
+    funciones: Map<string, FuncionAnalizada>;
+    objetos: Map<string, ObjetoAnalizado>;
+    variables: Map<string, VariableAnalizada>;
+    exportaciones: Map<string, ExportacionAnalizada[]>;
+}
+
+const conocimientoEjemplos: ConocimientoGlobal = {
+    funciones: new Map(),
+    objetos: new Map(),
+    variables: new Map(),
+    exportaciones: new Map()
+};
+
+const archivosUsuario = new Map<string, RegistroAnalisis>();
+let carpetasTrabajo: string[] = [];
+let rutaEjemplos: string | undefined;
+
+function uriAPathFs(uri: string): string {
+    try {
+        if (uri.startsWith('file://')) {
+            return fileURLToPath(uri);
+        }
+    } catch (error) {
+        connection.console.error(`No se pudo convertir URI a ruta: ${uri}`);
+    }
+    return uri;
+}
+
+function esQuetzal(ruta: string): boolean {
+    return ruta.toLowerCase().endsWith('.qz');
+}
+
+async function listarArchivosQuetzal(carpeta: string): Promise<string[]> {
+    const resultado: string[] = [];
+    try {
+        const entradas = await fs.promises.readdir(carpeta, { withFileTypes: true });
+        for (const entrada of entradas) {
+            if (entrada.name === 'node_modules' || entrada.name === '.git' || entrada.name === 'out') {
+                continue;
+            }
+            const rutaCompleta = path.join(carpeta, entrada.name);
+            if (entrada.isDirectory()) {
+                const internos = await listarArchivosQuetzal(rutaCompleta);
+                resultado.push(...internos);
+            } else if (entrada.isFile() && esQuetzal(entrada.name)) {
+                resultado.push(path.normalize(rutaCompleta));
+            }
+        }
+    } catch (error) {
+        connection.console.warn(`No se pudo listar carpeta ${carpeta}: ${String(error)}`);
+    }
+    return resultado;
+}
+
+async function cargarEjemplosDesdeCarpeta(carpeta: string): Promise<void> {
+    try {
+        const archivos = await listarArchivosQuetzal(carpeta);
+        for (const archivo of archivos) {
+            await registrarAnalisis(archivo, 'ejemplo');
+        }
+    } catch (error) {
+        connection.console.warn(`No se pudieron cargar ejemplos desde ${carpeta}: ${String(error)}`);
+    }
+}
+
+async function cargarArchivosUsuario(): Promise<void> {
+    archivosUsuario.clear();
+    for (const carpeta of carpetasTrabajo) {
+        const archivos = await listarArchivosQuetzal(carpeta);
+        for (const archivo of archivos) {
+            await registrarAnalisis(archivo, 'usuario');
+        }
+    }
+}
+
+async function registrarAnalisis(ruta: string, origen: OrigenArchivo, contenido?: string): Promise<void> {
+    try {
+        const texto = contenido ?? await fs.promises.readFile(ruta, 'utf8');
+        const analisis = analizarTextoQuetzal(texto);
+        const registro: RegistroAnalisis = { ruta: path.normalize(ruta), analisis };
+        if (origen === 'usuario') {
+            archivosUsuario.set(registro.ruta, registro);
+        } else {
+            agregarAnalisisEjemplo(registro);
+        }
+    } catch (error) {
+        connection.console.warn(`No se pudo analizar ${ruta}: ${String(error)}`);
+    }
+}
+
+function agregarAnalisisEjemplo(registro: RegistroAnalisis): void {
+    const { analisis, ruta } = registro;
+    for (const funcion of analisis.funciones) {
+        if (!conocimientoEjemplos.funciones.has(funcion.nombre)) {
+            conocimientoEjemplos.funciones.set(funcion.nombre, funcion);
+        }
+    }
+    for (const objeto of analisis.objetos) {
+        if (!conocimientoEjemplos.objetos.has(objeto.nombre)) {
+            conocimientoEjemplos.objetos.set(objeto.nombre, objeto);
+        }
+    }
+    for (const variable of analisis.variables) {
+        if (!conocimientoEjemplos.variables.has(variable.nombre)) {
+            conocimientoEjemplos.variables.set(variable.nombre, variable);
+        }
+    }
+    const rutaBase = rutaEjemplos ?? path.dirname(ruta);
+    const relativa = path.relative(rutaBase, ruta).replace(/\\/g, '/');
+    const baseNombre = path.basename(ruta);
+    const baseSinExtension = path.basename(ruta, '.qz');
+    const claves = new Set<string>([
+        relativa,
+        baseNombre,
+        `./${baseNombre}`,
+        baseSinExtension,
+        `./${baseSinExtension}`
+    ]);
+    for (const clave of claves) {
+        if (clave.length > 0) {
+            conocimientoEjemplos.exportaciones.set(clave, analisis.exportaciones);
+        }
+    }
+}
+
+function obtenerLinea(documento: TextDocument, indice: number): string {
+    const texto = documento.getText();
+    const lineas = texto.split(/\r?\n/);
+    return lineas[indice] ?? '';
+}
+
+function extraerPrefijoGeneral(documento: TextDocument, posicion: Position): string {
+    const linea = obtenerLinea(documento, posicion.line);
+    const antes = linea.slice(0, posicion.character);
+    const coincidencia = antes.match(/([\p{L}\p{N}_]+)$/u);
+    return coincidencia ? coincidencia[1] : '';
+}
+
+function detectarContextoMetodo(documento: TextDocument, posicion: Position): { identificador: string; prefijo: string } | null {
+    const linea = obtenerLinea(documento, posicion.line);
+    const antes = linea.slice(0, posicion.character);
+    const coincidencia = antes.match(new RegExp(String.raw`(${IDENTIFICADOR_REGEX})\.(\p{L}?[\p{L}\p{N}_]*)$`, 'u'));
+    if (!coincidencia) {
+        return null;
+    }
+    return { identificador: coincidencia[1], prefijo: coincidencia[2] ?? '' };
+}
+
+function detectarContextoImportacion(documento: TextDocument, posicion: Position): { modulo: string; prefijo: string } | null {
+    const texto = documento.getText();
+    const offset = documento.offsetAt(posicion);
+    const hastaCursor = texto.slice(0, offset);
+    const indiceImportar = hastaCursor.lastIndexOf('importar');
+    if (indiceImportar === -1) {
+        return null;
+    }
+    const indiceLlave = texto.indexOf('{', indiceImportar);
+    if (indiceLlave === -1 || indiceLlave > offset) {
+        return null;
+    }
+    const indiceCierre = texto.indexOf('}', indiceLlave);
+    if (indiceCierre === -1 || offset > indiceCierre) {
+        return null;
+    }
+    const textoTrasCierre = texto.slice(indiceCierre, Math.min(texto.length, indiceCierre + 200));
+    const coincidenciaDesde = textoTrasCierre.match(/\}\s*desde\s*"([^"]+)"/);
+    if (!coincidenciaDesde) {
+        return null;
+    }
+    const modulo = coincidenciaDesde[1];
+    const dentro = texto.slice(indiceLlave + 1, offset);
+    const partes = dentro.split(/[,\n]/);
+    const ultimo = partes[partes.length - 1] ?? '';
+    const prefijo = ultimo.trim().split(/\s+/).pop() ?? '';
+    return { modulo, prefijo };
+}
+
+function detectarContextoRutaModulo(documento: TextDocument, posicion: Position): { prefijo: string } | null {
+    const linea = obtenerLinea(documento, posicion.line);
+    const antes = linea.slice(0, posicion.character);
+    const coincidencia = antes.match(/desde\s+"([^"}]*)$/);
+    if (!coincidencia) {
+        return null;
+    }
+    return { prefijo: coincidencia[1] };
+}
+
+function filtrarPorPrefijo(items: CompletionItem[], prefijo: string): CompletionItem[] {
+    if (!prefijo) {
+        return items;
+    }
+    const prefijoMin = prefijo.toLowerCase();
+    return items.filter(item => item.label.toString().toLowerCase().startsWith(prefijoMin));
+}
+
+function crearItemDesdePalabra(palabra: DefinicionPalabra): CompletionItem {
+    const item: CompletionItem = {
+        label: palabra.etiqueta,
+        kind: palabra.tipo,
+        detail: palabra.descripcion
+    };
+    if (palabra.snippet) {
+        item.insertText = palabra.snippet;
+        item.insertTextFormat = FORMATO_SNIPPET;
+    }
+    if (FUNCIONES_DEPRECADAS.includes(palabra)) {
+        item.tags = [CompletionItemTag.Deprecated];
+    }
+    return item;
+}
+
+function crearItemFuncion(funcion: FuncionAnalizada, detalle: string): CompletionItem {
+    const item: CompletionItem = {
+        label: funcion.nombre,
+        kind: CompletionItemKind.Function,
+        detail: detalle
+    };
+    if (funcion.parametros.length > 0) {
+        const partes = funcion.parametros.map((parametro, indice) => '${' + (indice + 1) + ':' + parametro + '}');
+        item.insertText = `${funcion.nombre}(${partes.join(', ')})`;
+        item.insertTextFormat = InsertTextFormat.Snippet;
+    } else {
+        item.insertText = `${funcion.nombre}()`;
+        item.insertTextFormat = InsertTextFormat.Snippet;
+    }
+    return item;
+}
+
+function crearItemVariable(nombre: string, tipo: string | undefined, clase: CompletionItemKind): CompletionItem {
+    const item: CompletionItem = {
+        label: nombre,
+        kind: clase
+    };
+    if (tipo) {
+        item.detail = `Tipo: ${tipo}`;
+    }
+    return item;
+}
+
+function agregarItem(lista: CompletionItem[], mapaEtiquetas: Set<string>, item: CompletionItem): void {
+    const clave = `${item.label}|${item.kind}`;
+    if (!mapaEtiquetas.has(clave)) {
+        mapaEtiquetas.add(clave);
+        lista.push(item);
+    }
+}
+
+function normalizarTipoBase(tipo?: string): string | undefined {
+    if (!tipo) {
+        return undefined;
+    }
+    const limpio = tipo.trim().toLowerCase();
+    if (limpio.startsWith('lista')) {
+        return 'lista';
+    }
+    if (limpio.includes('<')) {
+        return limpio.split('<')[0]?.trim();
+    }
+    if (limpio === 'numero' || limpio === 'número') {
+        return 'numero';
+    }
+    if (limpio === 'bool') {
+        return 'log';
+    }
+    return limpio;
+}
+
+function obtenerExportacionesDeModulo(modulo: string, documento: TextDocument): ExportacionAnalizada[] | undefined {
+    if (conocimientoEjemplos.exportaciones.has(modulo)) {
+        return conocimientoEjemplos.exportaciones.get(modulo);
+    }
+    const rutaDocumento = path.normalize(uriAPathFs(documento.uri));
+    const directorio = path.dirname(rutaDocumento);
+    const posiblesRutas: string[] = [];
+    if (path.isAbsolute(modulo)) {
+        posiblesRutas.push(path.normalize(modulo));
+        if (!modulo.endsWith('.qz')) {
+            posiblesRutas.push(path.normalize(`${modulo}.qz`));
+        }
+    } else {
+        posiblesRutas.push(path.normalize(path.resolve(directorio, modulo)));
+        if (!modulo.endsWith('.qz')) {
+            posiblesRutas.push(path.normalize(path.resolve(directorio, `${modulo}.qz`)));
+        }
+        for (const carpeta of carpetasTrabajo) {
+            posiblesRutas.push(path.normalize(path.resolve(carpeta, modulo)));
+            if (!modulo.endsWith('.qz')) {
+                posiblesRutas.push(path.normalize(path.resolve(carpeta, `${modulo}.qz`)));
+            }
+        }
+    }
+    for (const ruta of posiblesRutas) {
+        const registro = archivosUsuario.get(ruta);
+        if (registro) {
+            return registro.analisis.exportaciones;
+        }
+    }
+    return undefined;
+}
+
+function obtenerTipoImportado(nombre: string, analisis: AnalisisDocumento, documento: TextDocument): string | undefined {
+    for (const importacion of analisis.importaciones) {
+        for (const elemento of importacion.elementos) {
+            const alias = elemento.alias ?? elemento.nombre;
+            if (alias === nombre) {
+                const exportaciones = obtenerExportacionesDeModulo(importacion.modulo, documento);
+                if (exportaciones) {
+                    const encontrado = exportaciones.find(exp => exp.nombre === elemento.nombre);
+                    if (encontrado?.tipo) {
+                        return encontrado.tipo;
+                    }
+                }
+            }
+        }
+    }
+    return undefined;
+}
+
+function sugerirMetodos(documento: TextDocument, analisis: AnalisisDocumento, identificador: string): CompletionItem[] {
+    let tipo = analisis.identificadores.get(identificador);
+    if (!tipo) {
+        tipo = obtenerTipoImportado(identificador, analisis, documento);
+    }
+    if (!tipo && identificador === 'consola') {
+        tipo = 'consola';
+    }
+    const base = normalizarTipoBase(tipo);
+    if (!base) {
+        return [];
+    }
+    const definiciones = METODOS_PREDEFINIDOS[base];
+    if (!definiciones) {
+        return [];
+    }
+    return definiciones.map(definicion => {
+        const item: CompletionItem = {
+            label: definicion.nombre,
+            kind: CompletionItemKind.Method,
+            detail: definicion.retorno ? `Retorna ${definicion.retorno}` : 'Método'
+        };
+        const insertable = definicion.snippet ?? definicion.nombre;
+        item.insertText = insertable;
+        item.insertTextFormat = InsertTextFormat.Snippet;
+        return item;
+    });
+}
+
+function sugerirElementosImportacion(documento: TextDocument, modulo: string): CompletionItem[] {
+    const exportaciones = obtenerExportacionesDeModulo(modulo, documento);
+    if (!exportaciones) {
+        return [];
+    }
+    return exportaciones.map(exp => {
+        const item: CompletionItem = {
+            label: exp.nombre,
+            kind: CompletionItemKind.Reference,
+            detail: exp.tipo ? `Exportado (${exp.tipo})` : 'Exportado'
+        };
+        item.insertText = exp.nombre;
+        return item;
+    });
+}
+
+function sugerirRutasModulo(documento: TextDocument, prefijo: string): CompletionItem[] {
+    const rutaDocumento = path.normalize(uriAPathFs(documento.uri));
+    const directorio = path.dirname(rutaDocumento);
+    const items: CompletionItem[] = [];
+    const agregados = new Set<string>();
+    for (const registro of archivosUsuario.values()) {
+        const relativa = path.relative(directorio, registro.ruta).replace(/\\/g, '/');
+        let sugerencia = relativa;
+        if (!sugerencia.startsWith('.')) {
+            sugerencia = `./${sugerencia}`;
+        }
+        if (!sugerencia.toLowerCase().endsWith('.qz')) {
+            sugerencia += '.qz';
+        }
+        if (!prefijo || sugerencia.startsWith(prefijo)) {
+            if (!agregados.has(sugerencia)) {
+                agregados.add(sugerencia);
+                items.push({
+                    label: sugerencia,
+                    kind: CompletionItemKind.File,
+                    insertText: sugerencia
+                });
+            }
+        }
+    }
+    for (const [clave] of conocimientoEjemplos.exportaciones) {
+        if (!prefijo || clave.startsWith(prefijo)) {
+            if (!agregados.has(clave)) {
+                agregados.add(clave);
+                items.push({
+                    label: clave,
+                    kind: CompletionItemKind.File,
+                    insertText: clave
+                });
+            }
+        }
+    }
+    return items;
+}
+
+function generarCompletadosGenerales(analisis: AnalisisDocumento): CompletionItem[] {
+    const items: CompletionItem[] = [];
+    const agregados = new Set<string>();
+
+    for (const palabra of PALABRAS_RESERVADAS) {
+        agregarItem(items, agregados, crearItemDesdePalabra(palabra));
+    }
+    for (const tipo of TIPOS_BÁSICOS) {
+        agregarItem(items, agregados, crearItemDesdePalabra(tipo));
+    }
+    for (const dep of FUNCIONES_DEPRECADAS) {
+        agregarItem(items, agregados, crearItemDesdePalabra(dep));
+    }
+
+    for (const funcion of conocimientoEjemplos.funciones.values()) {
+        agregarItem(items, agregados, crearItemFuncion(funcion, 'Función de ejemplo'));
+    }
+
+    for (const funcion of analisis.funciones) {
+        agregarItem(items, agregados, crearItemFuncion(funcion, funcion.tipoRetorno ? `Función (${funcion.tipoRetorno})` : 'Función'));
+    }
+
+    for (const variable of analisis.variables) {
+        agregarItem(items, agregados, crearItemVariable(variable.nombre, variable.tipo, CompletionItemKind.Variable));
+    }
+
+    for (const objeto of analisis.objetos) {
+        agregarItem(items, agregados, crearItemVariable(objeto.nombre, 'Objeto', CompletionItemKind.Class));
+    }
+
+    for (const importacion of analisis.importaciones) {
+        for (const elemento of importacion.elementos) {
+            agregarItem(items, agregados, crearItemVariable(elemento.alias ?? elemento.nombre, undefined, CompletionItemKind.Reference));
+        }
+    }
+
+    for (const registro of archivosUsuario.values()) {
+        for (const funcion of registro.analisis.funciones) {
+            agregarItem(items, agregados, crearItemFuncion(funcion, 'Función del proyecto'));
+        }
+    }
+
+    return items;
+}
+
+connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
+    carpetasTrabajo = (params.workspaceFolders ?? []).map(folder => path.normalize(uriAPathFs(folder.uri)));
+    rutaEjemplos = params.initializationOptions?.rutaEjemplos;
+    if (rutaEjemplos) {
+        await cargarEjemplosDesdeCarpeta(rutaEjemplos);
+    }
+    await cargarArchivosUsuario();
+
+    return {
+        capabilities: {
+            textDocumentSync: TextDocumentSyncKind.Incremental,
+            completionProvider: {
+                resolveProvider: false,
+                triggerCharacters: ['.', '{', '"']
+            }
+        }
+    };
+});
+
+connection.onCompletion((params: CompletionParams): CompletionItem[] => {
+    const documento = documentos.get(params.textDocument.uri);
+    if (!documento) {
+        return [];
+    }
+    const analisis = analizarTextoQuetzal(documento.getText());
+
+    const contextoMetodo = detectarContextoMetodo(documento, params.position);
+    if (contextoMetodo) {
+        const metodos = sugerirMetodos(documento, analisis, contextoMetodo.identificador);
+        return filtrarPorPrefijo(metodos, contextoMetodo.prefijo);
+    }
+
+    const contextoImportacion = detectarContextoImportacion(documento, params.position);
+    if (contextoImportacion) {
+        const elementos = sugerirElementosImportacion(documento, contextoImportacion.modulo);
+        return filtrarPorPrefijo(elementos, contextoImportacion.prefijo);
+    }
+
+    const contextoRuta = detectarContextoRutaModulo(documento, params.position);
+    if (contextoRuta) {
+        return sugerirRutasModulo(documento, contextoRuta.prefijo);
+    }
+
+    const prefijo = extraerPrefijoGeneral(documento, params.position);
+    const items = generarCompletadosGenerales(analisis);
+    return filtrarPorPrefijo(items, prefijo);
+});
+
+documentos.onDidOpen(async evento => {
+    const ruta = uriAPathFs(evento.document.uri);
+    if (esQuetzal(ruta)) {
+        await registrarAnalisis(path.normalize(ruta), 'usuario', evento.document.getText());
+    }
+});
+
+documentos.onDidChangeContent(async evento => {
+    const ruta = uriAPathFs(evento.document.uri);
+    if (esQuetzal(ruta)) {
+        await registrarAnalisis(path.normalize(ruta), 'usuario', evento.document.getText());
+    }
+});
+
+documentos.onDidClose(async evento => {
+    const ruta = uriAPathFs(evento.document.uri);
+    if (esQuetzal(ruta)) {
+        if (fs.existsSync(ruta)) {
+            await registrarAnalisis(path.normalize(ruta), 'usuario');
+        } else {
+            archivosUsuario.delete(path.normalize(ruta));
+        }
+    }
+});
+
+connection.onDidChangeWatchedFiles(async evento => {
+    for (const cambio of evento.changes) {
+        const ruta = path.normalize(uriAPathFs(cambio.uri));
+        if (!esQuetzal(ruta)) {
+            continue;
+        }
+        if (cambio.type === FileChangeType.Deleted) {
+            archivosUsuario.delete(ruta);
+            continue;
+        }
+        await registrarAnalisis(ruta, 'usuario');
+    }
+});
+
+documentos.listen(connection);
+connection.listen();


### PR DESCRIPTION
## Resumen
- incorporar un servidor de lenguaje LSP que aprovecha los ejemplos oficiales de Quetzal para alimentar el autocompletado y la búsqueda de módulos
- agregar inicialización del cliente de lenguaje desde la extensión y definir eventos de activación apropiados
- incluir los ejemplos de Quetzal dentro de la extensión para analizarlos y ofrecer sugerencias contextualizadas

## Pruebas
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d35f74bf30832fb26abd63d9117fee