### PR TITLE
Activar proveedor de autocompletado y hover para Quetzal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,11 +3,17 @@ import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { FormateadorQuetzal } from './formateador';
 import { DiagnosticadorQuetzal } from './diagnosticador';
+import { ProveedorCompletado } from './proveedor_completado';
+import { ServidorLenguajeQuetzal } from './servidor_lenguaje';
 
 let clienteLenguaje: LanguageClient | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Extensión Lenguaje Quetzal activada');
+
+    // Instancias compartidas para características del lenguaje
+    const servidorLenguajeInterno = new ServidorLenguajeQuetzal();
+    const proveedorAutocompletado = new ProveedorCompletado(servidorLenguajeInterno);
 
     // Inicializar servidor de lenguaje con implementación LSP
     inicializar_servidor_lenguaje(context);
@@ -74,13 +80,32 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.textDocuments.forEach(actualizar_diagnosticos);
 
     // Agregar disposables al contexto
+    const proveedorHover = vscode.languages.registerHoverProvider('quetzal', {
+        provideHover(document, position) {
+            const rangoPalabra = document.getWordRangeAtPosition(position, /[\p{L}\p{N}_]+/u);
+            if (!rangoPalabra) {
+                return null;
+            }
+            const palabra = document.getText(rangoPalabra);
+            return proveedorAutocompletado.obtener_informacion_hover(palabra);
+        }
+    });
+
+    const proveedorCompletadoDispos = vscode.languages.registerCompletionItemProvider(
+        { language: 'quetzal', scheme: 'file' },
+        proveedorAutocompletado,
+        '.'
+    );
+
     context.subscriptions.push(
         comando_formatear,
         comando_ejecutar,
         proveedor_formato,
         coleccion_diagnosticos,
         cambio_documento,
-        apertura_documento
+        apertura_documento,
+        proveedorCompletadoDispos,
+        proveedorHover
     );
 
     vscode.window.showInformationMessage('¡Lenguaje Quetzal listo para usar!');

--- a/src/proveedor_completado.ts
+++ b/src/proveedor_completado.ts
@@ -24,11 +24,16 @@ export class ProveedorCompletado implements vscode.CompletionItemProvider {
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
     ): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
-        
+        const configuracion = vscode.workspace.getConfiguration('quetzal');
+        const autocompletadoHabilitado = configuracion.get<boolean>('autocompletado.habilitado', true);
+        if (!autocompletadoHabilitado) {
+            return [];
+        }
+
         const linea_actual = document.lineAt(position.line);
         const texto_antes_cursor = linea_actual.text.substring(0, position.character);
-        
-    const completados: vscode.CompletionItem[] = [];
+
+        const completados: vscode.CompletionItem[] = [];
 
         // Agregar palabras reservadas
         completados.push(...this.palabras_reservadas);
@@ -40,11 +45,11 @@ export class ProveedorCompletado implements vscode.CompletionItemProvider {
         completados.push(...this.funciones_builtin);
 
         // Agregar completados contextuales
-    completados.push(...this.obtener_completados_contextuales(document, position));
+        completados.push(...this.obtener_completados_contextuales(document, position));
 
-    // Autocompletado por tipo si hay un identificador antes de un punto
-    const tipados = this.obtener_completados_por_tipo(document, position, texto_antes_cursor);
-    completados.push(...tipados);
+        // Autocompletado por tipo si hay un identificador antes de un punto
+        const tipados = this.obtener_completados_por_tipo(document, position, texto_antes_cursor);
+        completados.push(...tipados);
 
         // Filtrar por relevancia
         return this.filtrar_completados(completados, texto_antes_cursor);
@@ -142,7 +147,7 @@ export class ProveedorCompletado implements vscode.CompletionItemProvider {
         const completados: vscode.CompletionItem[] = [];
         
         // Obtener funciones definidas en el documento
-    const funciones_documento = this.extraer_funciones_documento(document);
+        const funciones_documento = this.extraer_funciones_documento(document);
         funciones_documento.forEach(funcion => {
             completados.push(this.crear_item_funcion_usuario(funcion));
         });


### PR DESCRIPTION
## Resumen
- Registrar el proveedor de autocompletado y hover del lenguaje Quetzal desde la activación de la extensión.
- Respetar la configuración `quetzal.autocompletado.habilitado` antes de entregar sugerencias de código.

## Pruebas
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68d7608caf78832fbda8ff9a51a10a21